### PR TITLE
Node.jsレッスン [q2] 　todoの総件数と完了済みtodoの件数表示機能の実装

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -19,6 +19,7 @@ export default new Vuex.Store({
     loginUser: (state) => state.loginUser,
     isAuthenticated: (state) => state.isAuthenticated,
     todoList: (state) => state.todoList,
+    completedTodos: (state) => state.todoList.filter((todo) => todo.isCompleted === 1),
   },
   mutations: {
     updateLoginUser(state, user) {

--- a/client/src/views/pages/Home.vue
+++ b/client/src/views/pages/Home.vue
@@ -6,8 +6,8 @@
     </template>
     <template>
       <div class="list-status">
-        <p>総件数: </p>
-        <p>完了済み: </p>
+        <p>総件数: {{ todoList.length }}</p>
+        <p>完了済み: {{ completedTodos.length }}</p>
       </div>
     </template>
     <template>
@@ -51,6 +51,7 @@ export default {
   computed: {
     ...mapGetters([
       'todoList',
+      'completedTodos',
     ]),
   },
 };


### PR DESCRIPTION
**変更内容**

・「/home」ページにてtodoの総件数と完了済みtodoの件数を表示させる様変更しました。

**確認事項**

・総件数はTodoの総件数を、完了済みはisCompletedがTrueのものがカウントされてるか。
・Storeに適切なGettersが実装されているか。

ご確認のほど、何卒よろしくお願いいたします。