### PR TITLE
Node.jsレッスン [q4] 　Loginページのリファクタ

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -44,29 +44,29 @@ const router = new VueRouter({
   routes,
 });
 
-// router.beforeEach(async (to, from, next) => {
-  // // 初回アクセスの場合
-  // if (to.name === 'login' && !from.name) {
-  //   return next();
-  // }
+router.beforeEach(async (to, from, next) => {
+  // 初回アクセスの場合
+  if (to.name === 'login' && !from.name) {
+    return next();
+  }
 
-//   await store.dispatch('checkAuthenticated');
-//   const { isAuthenticated } = store.getters;
+  await store.dispatch('checkAuthenticated');
+  const { isAuthenticated } = store.getters;
 
-//   // isPublic でない場合(=認証が必要な場合)、かつ、ログインしていない場合
-//   if (!to.meta.isPublic && !isAuthenticated) {
-//     return next({
-//       name: 'login',
-//     });
-//   }
+  // isPublic でない場合(=認証が必要な場合)、かつ、ログインしていない場合
+  if (!to.meta.isPublic && !isAuthenticated) {
+    return next({
+      name: 'login',
+    });
+  }
 
-//   // ログイン済みのユーザーはログインページにアクセスできないようにする
-//   if (to.name === 'login' && isAuthenticated) {
-//     return next({
-//       name: 'home',
-//     });
-//   }
-//   return next();
-// });
+  // ログイン済みのユーザーはログインページにアクセスできないようにする
+  if (to.name === 'login' && isAuthenticated) {
+    return next({
+      name: 'home',
+    });
+  }
+  return next();
+});
 
 export default router;

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -45,11 +45,7 @@ const router = new VueRouter({
 });
 
 router.beforeEach(async (to, from, next) => {
-  // 初回アクセスの場合
-  if (to.name === 'login' && !from.name) {
-    return next();
-  }
-
+  
   await store.dispatch('checkAuthenticated');
   const { isAuthenticated } = store.getters;
 
@@ -66,6 +62,12 @@ router.beforeEach(async (to, from, next) => {
       name: 'home',
     });
   }
+
+  // 初回アクセスの場合
+  if (to.name === 'login' && !from.name) {
+    return next();
+  }
+
   return next();
 });
 

--- a/client/src/views/components/LoginForm.vue
+++ b/client/src/views/components/LoginForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <form class="login-form" @submit.prevent="login">
+  <form class="login-form" @submit.prevent="$emit('login', user)">
     <div class="row">
       <label>
         username:
@@ -19,7 +19,6 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
 
 export default {
   data() {
@@ -29,29 +28,7 @@ export default {
         password: '',
       },
     };
-  },
-  methods: {
-    login() {
-      const param = {
-        username: this.user.username,
-        password: this.user.password,
-      };
-      this.$store.dispatch('updateLoginUser', param);
-    },
-  },
-  computed: {
-    ...mapState([
-      'loginUser',
-      'isAuthenticated',
-    ]),
-  },
-  watch: {
-    isAuthenticated() {
-      if (this.isAuthenticated) {
-        this.$router.push({ name: 'home' });
-      }
-    },
-  },
+  }
 };
 </script>
 

--- a/client/src/views/pages/Login.vue
+++ b/client/src/views/pages/Login.vue
@@ -1,13 +1,33 @@
 <template>
-  <my-login-form />
+  <my-login-form
+    @login="updateLoginUser"
+  />
 </template>
 
 <script>
 import MyLoginForm from '@/components/LoginForm.vue';
+import { mapActions, mapGetters } from 'vuex';
 
 export default {
   components: {
     MyLoginForm,
+  },
+  methods: {
+    ...mapActions([
+      'updateLoginUser',
+    ]),
+  },
+  computed: {
+    ...mapGetters([
+      'isAuthenticated',
+    ]),
+  },
+  watch: {
+    isAuthenticated() {
+      if (this.isAuthenticated) {
+        this.$router.push({ name: 'home' });
+      }
+    },
   },
 };
 </script>


### PR DESCRIPTION
**変更内容**

- 子コンポーネントに定義されたmethodsなどを親コンポーネントに定義し直す
Loginページにて、子コンポーネントのLoginFormコンポーネントでmethodsの定義や、Storeへのアクセスを行なっていたため、親コンポーネントのLoginコンポーネント内にmethods,computed,watchを定義し直しました。

- ログイン中なのに、URL欄に「/login」を入力し画面遷移をすると、ログインページへ画面遷移できてしまうバグを修正。
ルート単位のナビゲーションガード(router.beforeEach)にて認証済みかどうか確認する処理を一番最初に処理される様変更しました。